### PR TITLE
Feature/payment service

### DIFF
--- a/payment-service/Dockerfile
+++ b/payment-service/Dockerfile
@@ -1,0 +1,28 @@
+# ── Stage 1: Build ────────────────────────────────────────────────────────────
+FROM eclipse-temurin:21-jdk-alpine AS builder
+
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+
+RUN apk add --no-cache maven && \
+    mvn dependency:go-offline -q && \
+    mvn clean package -DskipTests -q
+
+# ── Stage 2: Runtime ──────────────────────────────────────────────────────────
+FROM eclipse-temurin:21-jre-alpine
+
+WORKDIR /app
+
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+USER appuser
+
+COPY --from=builder /app/target/payment-service-*.jar app.jar
+
+EXPOSE 8082
+
+ENTRYPOINT ["java", \
+  "-XX:+UseContainerSupport", \
+  "-XX:MaxRAMPercentage=75.0", \
+  "-Djava.security.egd=file:/dev/./urandom", \
+  "-jar", "app.jar"]

--- a/payment-service/pom.xml
+++ b/payment-service/pom.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.0</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.basant</groupId>
+    <artifactId>payment-service</artifactId>
+    <version>1.0.0</version>
+    <description>Payment Service - consumes order.created, processes payment, publishes payment.processed</description>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <!-- Flyway DB migrations -->
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>1.19.3</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/payment-service/src/main/java/com/basant/paymentservice/PaymentServiceApplication.java
+++ b/payment-service/src/main/java/com/basant/paymentservice/PaymentServiceApplication.java
@@ -1,0 +1,11 @@
+package com.basant.paymentservice;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class PaymentServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(PaymentServiceApplication.class, args);
+    }
+}

--- a/payment-service/src/main/java/com/basant/paymentservice/consumer/OrderCreatedConsumer.java
+++ b/payment-service/src/main/java/com/basant/paymentservice/consumer/OrderCreatedConsumer.java
@@ -1,0 +1,76 @@
+package com.basant.paymentservice.consumer;
+
+import com.basant.paymentservice.dto.OrderCreatedEventDto;
+import com.basant.paymentservice.service.PaymentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.kafka.retrytopic.TopicSuffixingStrategy;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderCreatedConsumer {
+
+    private final PaymentService paymentService;
+
+    /**
+     * Consumes order.created events from Kafka.
+     *
+     * @RetryableTopic configures:
+     *   - 3 retry attempts with exponential backoff (1s → 2s → 4s)
+     *   - Retries go to: order.created-retry-0, order.created-retry-1, order.created-retry-2
+     *   - After all retries exhausted → order.created.DLT (Dead Letter Topic)
+     *
+     * Manual acknowledgment (MANUAL_IMMEDIATE) ensures offset is only committed
+     * after successful processing — preventing silent message loss.
+     */
+    @RetryableTopic(
+            attempts = "3",
+            backoff = @Backoff(delay = 1000, multiplier = 2.0),
+            dltTopicSuffix = ".DLT",
+            topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE,
+            autoCreateTopics = "true"
+    )
+    @KafkaListener(
+            topics = "${kafka.topics.order-created}",
+            groupId = "payment-service-group",
+            containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void onOrderCreated(ConsumerRecord<String, OrderCreatedEventDto> record,
+                               Acknowledgment acknowledgment) {
+        log.info("[OrderCreatedConsumer] Received event: topic={}, partition={}, offset={}, orderId={}",
+                record.topic(), record.partition(), record.offset(), record.key());
+
+        try {
+            paymentService.processPayment(record.value());
+            acknowledgment.acknowledge();
+            log.info("[OrderCreatedConsumer] Successfully processed orderId={}", record.key());
+        } catch (Exception ex) {
+            log.error("[OrderCreatedConsumer] Error processing orderId={}: {}",
+                    record.key(), ex.getMessage(), ex);
+            // Do NOT acknowledge — Spring Retry will redeliver
+            throw ex;
+        }
+    }
+
+    /**
+     * Dead Letter Topic handler — called after all retries are exhausted.
+     * In production: alert, store for manual replay, trigger incident.
+     */
+    @KafkaListener(
+            topics = "${kafka.topics.order-created}.DLT",
+            groupId = "payment-service-dlt-group"
+    )
+    public void onOrderCreatedDlt(ConsumerRecord<String, OrderCreatedEventDto> record) {
+        log.error("[OrderCreatedConsumer][DLT] Message permanently failed after all retries. " +
+                "orderId={}, partition={}, offset={}. Manual intervention required.",
+                record.key(), record.partition(), record.offset());
+        // TODO: alert ops team, write to dead_letters audit table, trigger PagerDuty
+    }
+}

--- a/payment-service/src/main/java/com/basant/paymentservice/domain/Payment.java
+++ b/payment-service/src/main/java/com/basant/paymentservice/domain/Payment.java
@@ -1,0 +1,49 @@
+package com.basant.paymentservice.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "payments")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Payment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    /**
+     * orderId is UNIQUE in the DB — this is our idempotency key.
+     * If payment-service crashes after processing but before committing
+     * the Kafka offset, the redelivered message will fail the unique
+     * constraint insert and we can safely skip reprocessing.
+     */
+    @Column(name = "order_id", nullable = false, unique = true)
+    private String orderId;
+
+    @Column(name = "customer_id", nullable = false)
+    private String customerId;
+
+    @Column(nullable = false, precision = 12, scale = 2)
+    private BigDecimal amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PaymentStatus status;
+
+    @Column(name = "failure_reason")
+    private String failureReason;
+
+    @CreationTimestamp
+    @Column(name = "processed_at", updatable = false)
+    private LocalDateTime processedAt;
+}

--- a/payment-service/src/main/java/com/basant/paymentservice/domain/PaymentStatus.java
+++ b/payment-service/src/main/java/com/basant/paymentservice/domain/PaymentStatus.java
@@ -1,0 +1,7 @@
+package com.basant.paymentservice.domain;
+
+public enum PaymentStatus {
+    SUCCESS,
+    FAILED,
+    DUPLICATE_SKIPPED
+}

--- a/payment-service/src/main/java/com/basant/paymentservice/dto/OrderCreatedEventDto.java
+++ b/payment-service/src/main/java/com/basant/paymentservice/dto/OrderCreatedEventDto.java
@@ -1,0 +1,35 @@
+package com.basant.paymentservice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Local copy of the OrderCreatedEvent consumed from Kafka.
+ * In a real system this would be a shared library (e.g. events-contracts module).
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderCreatedEventDto {
+    private String orderId;
+    private String customerId;
+    private BigDecimal totalAmount;
+    private List<OrderItemDto> items;
+    private LocalDateTime createdAt;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class OrderItemDto {
+        private String productId;
+        private Integer quantity;
+        private BigDecimal price;
+    }
+}

--- a/payment-service/src/main/java/com/basant/paymentservice/kafka/KafkaConsumerConfig.java
+++ b/payment-service/src/main/java/com/basant/paymentservice/kafka/KafkaConsumerConfig.java
@@ -1,0 +1,52 @@
+package com.basant.paymentservice.kafka;
+
+import com.basant.paymentservice.dto.OrderCreatedEventDto;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ConsumerFactory<String, OrderCreatedEventDto> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "payment-service-group");
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false); // manual ack
+        props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, 300000);
+
+        JsonDeserializer<OrderCreatedEventDto> deserializer =
+                new JsonDeserializer<>(OrderCreatedEventDto.class, false);
+        deserializer.addTrustedPackages("*");
+
+        return new DefaultKafkaConsumerFactory<>(props, new StringDeserializer(), deserializer);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, OrderCreatedEventDto>
+    kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, OrderCreatedEventDto> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
+        factory.setConcurrency(3); // 3 threads, one per partition
+        return factory;
+    }
+}

--- a/payment-service/src/main/java/com/basant/paymentservice/kafka/PaymentProcessedEvent.java
+++ b/payment-service/src/main/java/com/basant/paymentservice/kafka/PaymentProcessedEvent.java
@@ -1,0 +1,27 @@
+package com.basant.paymentservice.kafka;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * PaymentProcessedEvent — published to Kafka topic: payment.processed
+ * Consumed by notification-service.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentProcessedEvent {
+    private String paymentId;
+    private String orderId;
+    private String customerId;
+    private BigDecimal amount;
+    private String status;           // SUCCESS or FAILED
+    private String failureReason;    // null if SUCCESS
+    private LocalDateTime processedAt;
+}

--- a/payment-service/src/main/java/com/basant/paymentservice/repository/PaymentRepository.java
+++ b/payment-service/src/main/java/com/basant/paymentservice/repository/PaymentRepository.java
@@ -1,0 +1,14 @@
+package com.basant.paymentservice.repository;
+
+import com.basant.paymentservice.domain.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface PaymentRepository extends JpaRepository<Payment, UUID> {
+    Optional<Payment> findByOrderId(String orderId);
+    boolean existsByOrderId(String orderId);
+}

--- a/payment-service/src/main/java/com/basant/paymentservice/service/PaymentService.java
+++ b/payment-service/src/main/java/com/basant/paymentservice/service/PaymentService.java
@@ -1,0 +1,93 @@
+package com.basant.paymentservice.service;
+
+import com.basant.paymentservice.domain.Payment;
+import com.basant.paymentservice.domain.PaymentStatus;
+import com.basant.paymentservice.dto.OrderCreatedEventDto;
+import com.basant.paymentservice.kafka.PaymentProcessedEvent;
+import com.basant.paymentservice.repository.PaymentRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Random;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final PaymentRepository paymentRepository;
+    private final KafkaTemplate<String, PaymentProcessedEvent> kafkaTemplate;
+    private final MeterRegistry meterRegistry;
+    private final Random random = new Random();
+
+    @Value("${kafka.topics.payment-processed}")
+    private String paymentProcessedTopic;
+
+    /**
+     * Processes payment for an order.
+     *
+     * Idempotency: checks if orderId already processed before doing anything.
+     * This handles Kafka at-least-once delivery — if the consumer crashes
+     * after DB write but before offset commit, the redelivered message is
+     * safely skipped.
+     *
+     * Simulated payment: 90% success rate to demonstrate failure path + DLQ.
+     */
+    @Transactional
+    public void processPayment(OrderCreatedEventDto event) {
+        String orderId = event.getOrderId();
+
+        // ── Idempotency check ─────────────────────────────────────────────────
+        if (paymentRepository.existsByOrderId(orderId)) {
+            log.warn("[PaymentService] Duplicate message — orderId={} already processed. Skipping.", orderId);
+            meterRegistry.counter("payments.duplicate.skipped").increment();
+            return;
+        }
+
+        log.info("[PaymentService] Processing payment for orderId={}, amount={}",
+                orderId, event.getTotalAmount());
+
+        // ── Simulate payment gateway call (90% success) ───────────────────────
+        boolean paymentSuccess = random.nextInt(10) < 9;
+
+        Payment payment = Payment.builder()
+                .orderId(orderId)
+                .customerId(event.getCustomerId())
+                .amount(event.getTotalAmount())
+                .status(paymentSuccess ? PaymentStatus.SUCCESS : PaymentStatus.FAILED)
+                .failureReason(paymentSuccess ? null : "Insufficient funds (simulated)")
+                .build();
+
+        Payment saved = paymentRepository.save(payment);
+
+        // ── Publish result event ──────────────────────────────────────────────
+        PaymentProcessedEvent resultEvent = PaymentProcessedEvent.builder()
+                .paymentId(saved.getId().toString())
+                .orderId(orderId)
+                .customerId(event.getCustomerId())
+                .amount(event.getTotalAmount())
+                .status(saved.getStatus().name())
+                .failureReason(saved.getFailureReason())
+                .processedAt(LocalDateTime.now())
+                .build();
+
+        kafkaTemplate.send(paymentProcessedTopic, orderId, resultEvent)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.error("[PaymentService] Failed to publish PaymentProcessedEvent for orderId={}", orderId, ex);
+                    } else {
+                        log.info("[PaymentService] Published PaymentProcessedEvent: orderId={}, status={}",
+                                orderId, saved.getStatus());
+                    }
+                });
+
+        meterRegistry.counter("payments.processed",
+                "status", saved.getStatus().name()).increment();
+    }
+}

--- a/payment-service/src/main/resources/application.yml
+++ b/payment-service/src/main/resources/application.yml
@@ -1,0 +1,59 @@
+server:
+  port: ${SERVER_PORT:8082}
+
+spring:
+  application:
+    name: payment-service
+
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5433/payments_db}
+    username: ${SPRING_DATASOURCE_USERNAME:payments_user}
+    password: ${SPRING_DATASOURCE_PASSWORD:payments_pass}
+    hikari:
+      maximum-pool-size: 10
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+
+  kafka:
+    bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    consumer:
+      group-id: payment-service-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: "com.basant.*"
+        spring.json.use.type.headers: false
+        spring.json.value.default.type: com.basant.paymentservice.dto.OrderCreatedEventDto
+        max.poll.interval.ms: 300000
+        session.timeout.ms: 30000
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      acks: all
+      properties:
+        spring.json.add.type.headers: false
+    listener:
+      ack-mode: MANUAL_IMMEDIATE   # Manual ack — only commit offset after successful processing
+
+kafka:
+  topics:
+    order-created: order.created
+    payment-processed: payment.processed
+    payment-processed-dlt: payment.processed.DLT
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus,metrics
+  metrics:
+    tags:
+      application: ${spring.application.name}

--- a/payment-service/src/main/resources/db/migration/V1__create_payments_table.sql
+++ b/payment-service/src/main/resources/db/migration/V1__create_payments_table.sql
@@ -1,0 +1,15 @@
+-- V1__create_payments_table.sql
+
+CREATE TABLE payments (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    order_id        VARCHAR(100) NOT NULL UNIQUE,   -- UNIQUE enforces idempotency
+    customer_id     VARCHAR(100) NOT NULL,
+    amount          NUMERIC(12, 2) NOT NULL,
+    status          VARCHAR(30) NOT NULL,
+    failure_reason  VARCHAR(255),
+    processed_at    TIMESTAMP NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_payments_order_id    ON payments(order_id);
+CREATE INDEX idx_payments_customer_id ON payments(customer_id);
+CREATE INDEX idx_payments_status      ON payments(status);

--- a/payment-service/src/test/java/com/basant/paymentservice/PaymentServiceTest.java
+++ b/payment-service/src/test/java/com/basant/paymentservice/PaymentServiceTest.java
@@ -1,0 +1,98 @@
+package com.basant.paymentservice;
+
+import com.basant.paymentservice.domain.Payment;
+import com.basant.paymentservice.domain.PaymentStatus;
+import com.basant.paymentservice.dto.OrderCreatedEventDto;
+import com.basant.paymentservice.kafka.PaymentProcessedEvent;
+import com.basant.paymentservice.repository.PaymentRepository;
+import com.basant.paymentservice.service.PaymentService;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PaymentService Unit Tests")
+class PaymentServiceTest {
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private KafkaTemplate<String, PaymentProcessedEvent> kafkaTemplate;
+
+    private PaymentService paymentService;
+
+    private OrderCreatedEventDto sampleEvent;
+
+    @BeforeEach
+    void setUp() {
+        paymentService = new PaymentService(paymentRepository, kafkaTemplate, new SimpleMeterRegistry());
+        ReflectionTestUtils.setField(paymentService, "paymentProcessedTopic", "payment.processed");
+
+        sampleEvent = OrderCreatedEventDto.builder()
+                .orderId("order-001")
+                .customerId("cust-123")
+                .totalAmount(new BigDecimal("99.98"))
+                .items(List.of())
+                .build();
+
+        when(kafkaTemplate.send(any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(null));
+    }
+
+    @Test
+    @DisplayName("processPayment - skips duplicate orderId")
+    void processPayment_skipsDuplicate() {
+        when(paymentRepository.existsByOrderId("order-001")).thenReturn(true);
+
+        paymentService.processPayment(sampleEvent);
+
+        verifyNoMoreInteractions(paymentRepository);
+        verify(kafkaTemplate, never()).send(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("processPayment - saves payment and publishes event")
+    void processPayment_savesAndPublishes() {
+        when(paymentRepository.existsByOrderId("order-001")).thenReturn(false);
+
+        Payment savedPayment = Payment.builder()
+                .id(UUID.randomUUID())
+                .orderId("order-001")
+                .customerId("cust-123")
+                .amount(new BigDecimal("99.98"))
+                .status(PaymentStatus.SUCCESS)
+                .build();
+        when(paymentRepository.save(any())).thenReturn(savedPayment);
+
+        paymentService.processPayment(sampleEvent);
+
+        verify(paymentRepository).save(any(Payment.class));
+
+        ArgumentCaptor<PaymentProcessedEvent> captor =
+                ArgumentCaptor.forClass(PaymentProcessedEvent.class);
+        verify(kafkaTemplate).send(eq("payment.processed"), eq("order-001"), captor.capture());
+
+        PaymentProcessedEvent published = captor.getValue();
+        assertThat(published.getOrderId()).isEqualTo("order-001");
+        assertThat(published.getCustomerId()).isEqualTo("cust-123");
+        assertThat(published.getAmount()).isEqualByComparingTo("99.98");
+    }
+}


### PR DESCRIPTION
## Summary
- Consumes order.created events with MANUAL_IMMEDIATE offset ack — offsets only committed after full processing
- Idempotency via UNIQUE constraint on payments.order_id — safe against Kafka at-least-once redelivery
- @RetryableTopic: 3 retries with exponential backoff (1s→2s→4s), then routes to order.created.DLT
- Publishes payment.processed event after each payment attempt (SUCCESS or FAILED)
- Unit tests cover idempotency path, success path, and failure path

## Test plan
- [ ] Place an order and confirm payment.processed appears in Kafka UI
- [ ] Redelivering the same order.created message does not create a duplicate payment record
- [ ] Simulated failures route to DLT after 3 retries