### PR TITLE
Feature/notification service

### DIFF
--- a/notification-service/Dockerfile
+++ b/notification-service/Dockerfile
@@ -1,0 +1,28 @@
+# ── Stage 1: Build ────────────────────────────────────────────────────────────
+FROM eclipse-temurin:21-jdk-alpine AS builder
+
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+
+RUN apk add --no-cache maven && \
+    mvn dependency:go-offline -q && \
+    mvn clean package -DskipTests -q
+
+# ── Stage 2: Runtime ──────────────────────────────────────────────────────────
+FROM eclipse-temurin:21-jre-alpine
+
+WORKDIR /app
+
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+USER appuser
+
+COPY --from=builder /app/target/notification-service-*.jar app.jar
+
+EXPOSE 8083
+
+ENTRYPOINT ["java", \
+  "-XX:+UseContainerSupport", \
+  "-XX:MaxRAMPercentage=75.0", \
+  "-Djava.security.egd=file:/dev/./urandom", \
+  "-jar", "app.jar"]

--- a/notification-service/pom.xml
+++ b/notification-service/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.0</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.basant</groupId>
+    <artifactId>notification-service</artifactId>
+    <version>1.0.0</version>
+    <description>Notification Service - consumes order and payment events, sends notifications</description>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/notification-service/src/main/java/com/basant/notificationservice/NotificationServiceApplication.java
+++ b/notification-service/src/main/java/com/basant/notificationservice/NotificationServiceApplication.java
@@ -1,0 +1,11 @@
+package com.basant.notificationservice;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class NotificationServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(NotificationServiceApplication.class, args);
+    }
+}

--- a/notification-service/src/main/java/com/basant/notificationservice/consumer/NotificationConsumer.java
+++ b/notification-service/src/main/java/com/basant/notificationservice/consumer/NotificationConsumer.java
@@ -1,0 +1,58 @@
+package com.basant.notificationservice.consumer;
+
+import com.basant.notificationservice.dto.EventDtos.OrderCreatedEventDto;
+import com.basant.notificationservice.dto.EventDtos.PaymentProcessedEventDto;
+import com.basant.notificationservice.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationConsumer {
+
+    private final NotificationService notificationService;
+
+    /**
+     * Listens to order.created — sends "order received" notification.
+     * Uses a separate consumer group so this service independently
+     * tracks its own offset, decoupled from payment-service.
+     */
+    @KafkaListener(
+            topics = "${kafka.topics.order-created}",
+            groupId = "notification-service-order-group",
+            containerFactory = "orderCreatedContainerFactory"
+    )
+    public void onOrderCreated(ConsumerRecord<String, OrderCreatedEventDto> record) {
+        log.info("[NotificationConsumer] order.created received: orderId={}, offset={}",
+                record.key(), record.offset());
+        try {
+            notificationService.handleOrderCreated(record.value());
+        } catch (Exception ex) {
+            log.error("[NotificationConsumer] Failed to handle order.created for orderId={}: {}",
+                    record.key(), ex.getMessage(), ex);
+        }
+    }
+
+    /**
+     * Listens to payment.processed — sends payment success/failure notification.
+     */
+    @KafkaListener(
+            topics = "${kafka.topics.payment-processed}",
+            groupId = "notification-service-payment-group",
+            containerFactory = "paymentProcessedContainerFactory"
+    )
+    public void onPaymentProcessed(ConsumerRecord<String, PaymentProcessedEventDto> record) {
+        log.info("[NotificationConsumer] payment.processed received: orderId={}, status={}",
+                record.key(), record.value() != null ? record.value().getStatus() : "null");
+        try {
+            notificationService.handlePaymentProcessed(record.value());
+        } catch (Exception ex) {
+            log.error("[NotificationConsumer] Failed to handle payment.processed for orderId={}: {}",
+                    record.key(), ex.getMessage(), ex);
+        }
+    }
+}

--- a/notification-service/src/main/java/com/basant/notificationservice/domain/Notification.java
+++ b/notification-service/src/main/java/com/basant/notificationservice/domain/Notification.java
@@ -1,0 +1,32 @@
+package com.basant.notificationservice.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * In-memory notification record.
+ * In production this would be persisted to a DB or pushed to
+ * an email/SMS provider (SendGrid, Twilio, AWS SNS, etc.)
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Notification {
+    private String id;
+    private String customerId;
+    private String orderId;
+    private NotificationType type;
+    private String message;
+    private LocalDateTime sentAt;
+
+    public enum NotificationType {
+        ORDER_RECEIVED,
+        PAYMENT_SUCCESS,
+        PAYMENT_FAILED
+    }
+}

--- a/notification-service/src/main/java/com/basant/notificationservice/dto/EventDtos.java
+++ b/notification-service/src/main/java/com/basant/notificationservice/dto/EventDtos.java
@@ -1,0 +1,45 @@
+package com.basant.notificationservice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class EventDtos {
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class OrderCreatedEventDto {
+        private String orderId;
+        private String customerId;
+        private BigDecimal totalAmount;
+        private List<OrderItemDto> items;
+        private LocalDateTime createdAt;
+
+        @Data
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class OrderItemDto {
+            private String productId;
+            private Integer quantity;
+            private BigDecimal price;
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PaymentProcessedEventDto {
+        private String paymentId;
+        private String orderId;
+        private String customerId;
+        private BigDecimal amount;
+        private String status;
+        private String failureReason;
+        private LocalDateTime processedAt;
+    }
+}

--- a/notification-service/src/main/java/com/basant/notificationservice/kafka/KafkaConsumerConfig.java
+++ b/notification-service/src/main/java/com/basant/notificationservice/kafka/KafkaConsumerConfig.java
@@ -1,0 +1,71 @@
+package com.basant.notificationservice.kafka;
+
+import com.basant.notificationservice.dto.EventDtos.OrderCreatedEventDto;
+import com.basant.notificationservice.dto.EventDtos.PaymentProcessedEventDto;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    private Map<String, Object> baseConsumerProps() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, true);
+        return props;
+    }
+
+    // ── Factory for order.created ──────────────────────────────────────────────
+
+    @Bean
+    public ConsumerFactory<String, OrderCreatedEventDto> orderCreatedConsumerFactory() {
+        JsonDeserializer<OrderCreatedEventDto> deserializer =
+                new JsonDeserializer<>(OrderCreatedEventDto.class, false);
+        deserializer.addTrustedPackages("*");
+        return new DefaultKafkaConsumerFactory<>(baseConsumerProps(),
+                new StringDeserializer(), deserializer);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, OrderCreatedEventDto>
+    orderCreatedContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, OrderCreatedEventDto> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(orderCreatedConsumerFactory());
+        return factory;
+    }
+
+    // ── Factory for payment.processed ─────────────────────────────────────────
+
+    @Bean
+    public ConsumerFactory<String, PaymentProcessedEventDto> paymentProcessedConsumerFactory() {
+        JsonDeserializer<PaymentProcessedEventDto> deserializer =
+                new JsonDeserializer<>(PaymentProcessedEventDto.class, false);
+        deserializer.addTrustedPackages("*");
+        return new DefaultKafkaConsumerFactory<>(baseConsumerProps(),
+                new StringDeserializer(), deserializer);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, PaymentProcessedEventDto>
+    paymentProcessedContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, PaymentProcessedEventDto> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(paymentProcessedConsumerFactory());
+        return factory;
+    }
+}

--- a/notification-service/src/main/java/com/basant/notificationservice/service/NotificationService.java
+++ b/notification-service/src/main/java/com/basant/notificationservice/service/NotificationService.java
@@ -1,0 +1,89 @@
+package com.basant.notificationservice.service;
+
+import com.basant.notificationservice.domain.Notification;
+import com.basant.notificationservice.domain.Notification.NotificationType;
+import com.basant.notificationservice.dto.EventDtos.OrderCreatedEventDto;
+import com.basant.notificationservice.dto.EventDtos.PaymentProcessedEventDto;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final MeterRegistry meterRegistry;
+
+    /**
+     * Handles order.created — notifies customer that order was received.
+     */
+    public void handleOrderCreated(OrderCreatedEventDto event) {
+        String message = String.format(
+                "Hi customer %s, your order %s for $%.2f has been received and is being processed.",
+                event.getCustomerId(), event.getOrderId(), event.getTotalAmount()
+        );
+
+        Notification notification = Notification.builder()
+                .id(UUID.randomUUID().toString())
+                .customerId(event.getCustomerId())
+                .orderId(event.getOrderId())
+                .type(NotificationType.ORDER_RECEIVED)
+                .message(message)
+                .sentAt(LocalDateTime.now())
+                .build();
+
+        send(notification);
+    }
+
+    /**
+     * Handles payment.processed — notifies customer of payment outcome.
+     */
+    public void handlePaymentProcessed(PaymentProcessedEventDto event) {
+        boolean success = "SUCCESS".equalsIgnoreCase(event.getStatus());
+
+        String message = success
+                ? String.format("Payment of $%.2f for order %s was successful! Your order is confirmed.",
+                        event.getAmount(), event.getOrderId())
+                : String.format("Payment of $%.2f for order %s failed. Reason: %s. Please retry.",
+                        event.getAmount(), event.getOrderId(), event.getFailureReason());
+
+        NotificationType type = success
+                ? NotificationType.PAYMENT_SUCCESS
+                : NotificationType.PAYMENT_FAILED;
+
+        Notification notification = Notification.builder()
+                .id(UUID.randomUUID().toString())
+                .customerId(event.getCustomerId())
+                .orderId(event.getOrderId())
+                .type(type)
+                .message(message)
+                .sentAt(LocalDateTime.now())
+                .build();
+
+        send(notification);
+    }
+
+    /**
+     * Simulates sending a notification.
+     * Replace with real provider: SendGrid (email), Twilio (SMS), AWS SNS, Firebase (push).
+     */
+    private void send(Notification notification) {
+        // Simulate delivery latency
+        log.info("[NotificationService] [{}] Sending to customer={}: {}",
+                notification.getType(),
+                notification.getCustomerId(),
+                notification.getMessage());
+
+        // In production: emailClient.send(...) or smsClient.send(...)
+        log.info("[NotificationService] [SIMULATED] Notification delivered: id={}, type={}, orderId={}",
+                notification.getId(), notification.getType(), notification.getOrderId());
+
+        meterRegistry.counter("notifications.sent",
+                "type", notification.getType().name()).increment();
+    }
+}

--- a/notification-service/src/main/resources/application.yml
+++ b/notification-service/src/main/resources/application.yml
@@ -1,0 +1,34 @@
+server:
+  port: ${SERVER_PORT:8083}
+
+spring:
+  application:
+    name: notification-service
+
+  kafka:
+    bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    consumer:
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: "com.basant.*"
+        spring.json.use.type.headers: false
+
+kafka:
+  topics:
+    order-created: order.created
+    payment-processed: payment.processed
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus,metrics
+  metrics:
+    tags:
+      application: ${spring.application.name}
+
+logging:
+  level:
+    com.basant: DEBUG

--- a/notification-service/src/test/java/com/basant/notificationservice/NotificationServiceTest.java
+++ b/notification-service/src/test/java/com/basant/notificationservice/NotificationServiceTest.java
@@ -1,0 +1,53 @@
+package com.basant.notificationservice;
+
+import com.basant.notificationservice.dto.EventDtos.OrderCreatedEventDto;
+import com.basant.notificationservice.dto.EventDtos.PaymentProcessedEventDto;
+import com.basant.notificationservice.service.NotificationService;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@DisplayName("NotificationService Unit Tests")
+class NotificationServiceTest {
+
+    private NotificationService notificationService;
+
+    @BeforeEach
+    void setUp() {
+        notificationService = new NotificationService(new SimpleMeterRegistry());
+    }
+
+    @Test
+    @DisplayName("handleOrderCreated - processes without error")
+    void handleOrderCreated_doesNotThrow() {
+        OrderCreatedEventDto event = new OrderCreatedEventDto(
+                "order-001", "cust-123", new BigDecimal("99.98"), null, null);
+
+        assertDoesNotThrow(() -> notificationService.handleOrderCreated(event));
+    }
+
+    @Test
+    @DisplayName("handlePaymentProcessed - success path")
+    void handlePaymentProcessed_success() {
+        PaymentProcessedEventDto event = new PaymentProcessedEventDto(
+                "pay-001", "order-001", "cust-123",
+                new BigDecimal("99.98"), "SUCCESS", null, null);
+
+        assertDoesNotThrow(() -> notificationService.handlePaymentProcessed(event));
+    }
+
+    @Test
+    @DisplayName("handlePaymentProcessed - failure path includes reason")
+    void handlePaymentProcessed_failure() {
+        PaymentProcessedEventDto event = new PaymentProcessedEventDto(
+                "pay-002", "order-002", "cust-456",
+                new BigDecimal("49.99"), "FAILED", "Insufficient funds (simulated)", null);
+
+        assertDoesNotThrow(() -> notificationService.handlePaymentProcessed(event));
+    }
+}


### PR DESCRIPTION
## Summary
- Stateless service consuming both order.created and payment.processed topics
- Two independent consumer groups so each topic is tracked separately
- Logs structured notifications on order received and payment success/failure
- Unit tests cover all three notification paths

## Test plan
- [ ] Place an order and confirm notification logs appear for order.created
- [ ] Confirm payment success/failure notification logs appear after payment.processed